### PR TITLE
Fix reference to decf - #12

### DIFF
--- a/php-cs-fixer.el
+++ b/php-cs-fixer.el
@@ -105,7 +105,7 @@ ARG is defined as for that function."
                 (forward-line len)
                 (let ((text (buffer-substring start (point))))
                   (with-current-buffer target-buffer
-                    (decf line-offset len)
+                    (cl-decf line-offset len)
                     (goto-char (point-min))
                     (forward-line (- from len line-offset))
                     (insert text)))))


### PR DESCRIPTION
when cl-lib was required, the
reference to incf was fixed,
but decf was missed.

Related to #9