### PR TITLE
Check for executable via `php-cs-fixer-command`

### DIFF
--- a/php-cs-fixer.el
+++ b/php-cs-fixer.el
@@ -161,7 +161,7 @@ for the next calls."
       (message "Testing php-cs-fixer existence and version...")
       (setq php-cs-fixer-is-command-ok-var 0)
 
-      (if (executable-find "php-cs-fixer")
+      (if (executable-find php-cs-fixer-command)
           (if (string-match ".+ [2-3].[0-9]+.*"
                             (shell-command-to-string
                              (concat php-cs-fixer-command " --version")))


### PR DESCRIPTION
This change allows users to use `php-cs-fixer` when the underlying executable is not in the PATH, or stored under a different name.

In several MacOS Emacs distributions, the PATH is not properly loaded on startup which causes binaries stored in non-default locations (such as `~/.composer/vendor/bin`) to not be loaded. Setting a custom `php-cs-fixer-command` value fixes that, but `php-cs-fixer--is-command-ok` still fails to recognize it since it only checks the default executable.