### PR TITLE
Handle php-cs-fixer-command errors

### DIFF
--- a/php-cs-fixer.el
+++ b/php-cs-fixer.el
@@ -198,21 +198,20 @@ for the next calls."
         ;; We're using errbuf for the mixed stdout and stderr output. This
         ;; is not an issue because  php-cs-fixer -q does not produce any stdout
         ;; output in case of success.
-        (if (zerop (call-process "php" nil errbuf nil "-l" tmpfile))
-            (progn
-              (call-process php-cs-fixer-command
-                            nil errbuf nil
-                            "fix"
-                            (if php-cs-fixer-config-option
-                                (concat "--config=" (shell-quote-argument php-cs-fixer-config-option))
-                              (php-cs-fixer--build-rules-options))
-                            "--using-cache=no"
-                            "--quiet"
-                            tmpfile)
-              (if (zerop (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-" tmpfile))
-                  (message "Buffer is already php-cs-fixed")
-                (php-cs-fixer--apply-rcs-patch patchbuf)
-                (message "Applied php-cs-fixer")))
+        (if (and (zerop (call-process "php" nil errbuf nil "-l" tmpfile))
+                 (zerop (call-process php-cs-fixer-command
+                                      nil errbuf nil
+                                      "fix"
+                                      (if php-cs-fixer-config-option
+                                          (concat "--config=" (shell-quote-argument php-cs-fixer-config-option))
+                                        (php-cs-fixer--build-rules-options))
+                                      "--using-cache=no"
+                                      "--quiet"
+                                      tmpfile)))
+            (if (zerop (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-" tmpfile))
+                (message "Buffer is already php-cs-fixed")
+              (php-cs-fixer--apply-rcs-patch patchbuf)
+              (message "Applied php-cs-fixer"))
           (warn (with-current-buffer errbuf (buffer-string)))))
 
       (php-cs-fixer--kill-error-buffer errbuf)


### PR DESCRIPTION
Show error buffer if php-cs-fixer-command fails.

This mode  did not work in my setup out-of-the box. 
Instead I always got the message  "Buffer is already php-cs-fixed" although the actual fixer process failed (the non-zero exit did not result in the error buffer being displayed)

Using this commit the actual root-cause is being displayed:

```
In ConfigurationResolver.php line 793:
                                                                               
  The rules contain unknown fixers: "psr0" is renamed (did you mean "psr_auto  
  loading"? (note: use configuration "[’dir’ => ’x’]")), "no_multiline_whites  
  pace_before_semicolons" is renamed (did you mean "multiline_whitespace_befo  
  re_semicolons"?).                                                            
 ...
```
