### PR TITLE
avoid `kill-region` altogether

### DIFF
--- a/php-cs-fixer.el
+++ b/php-cs-fixer.el
@@ -72,7 +72,9 @@ These options are not part of `php-cs-fixer-rules-level-part-options`."
   "Delete the current line without putting it in the `kill-ring`.
 Derived from the function `kill-whole-line'.
 ARG is defined as for that function."
-  (let (kill-ring) (kill-whole-line arg)))
+  (delete-region
+    (progn (forward-line 0) (point))
+    (progn (forward-line (or arg 0)) (point))))
 
 ;; Derivated of go--apply-rcs-patch from https://github.com/dominikh/go-mode.el
 (defun php-cs-fixer--apply-rcs-patch (patch-buffer)


### PR DESCRIPTION
Using `kill-whole-line` is calling `kill-region` which results in:

```
Debugger entered--Lisp error: (args-out-of-range 0 0)
  get-text-property(0 yank-handler nil)
  kill-append("" nil)
  kill-region(392 392)
  kill-whole-line(11)
  php-cs-fixer--delete-whole-line(11)
  php-cs-fixer--apply-rcs-patch(#<buffer *PHP-CS-Fixer patch*>)
  php-cs-fixer-fix()
  funcall-interactively(php-cs-fixer-fix)
  call-interactively(php-cs-fixer-fix record nil)
  command-execute(php-cs-fixer-fix record)
  execute-extended-command(nil "php-cs-fixer-fix" nil)
  funcall-interactively(execute-extended-command nil "php-cs-fixer-fix" nil)
  call-interactively(execute-extended-command nil nil)
  command-execute(execute-extended-command)
```

Since you just need to remove line(s) without putting it in the `kill-ring`,
you can use `delete-region` instead which works exactly as supposed to work.